### PR TITLE
Prevent synapse threads wait on PassThroughMessageProcessor

### DIFF
--- a/modules/httpcore-nio/src/main/java/org/apache/http/impl/nio/codecs/ChunkEncoder.java
+++ b/modules/httpcore-nio/src/main/java/org/apache/http/impl/nio/codecs/ChunkEncoder.java
@@ -90,7 +90,7 @@ public class ChunkEncoder extends AbstractContentEncoder {
         assertNotCompleted();
 
         int total = 0;
-        while (src.hasRemaining()) {
+        if (src.hasRemaining()) {
             int chunk = src.remaining();
             int avail;
             if (this.bufferinfo != null) {
@@ -128,7 +128,7 @@ public class ChunkEncoder extends AbstractContentEncoder {
             if (this.buffer.length() >= this.fragHint || src.hasRemaining()) {
                 final int bytesWritten = flushToChannel();
                 if (bytesWritten == 0) {
-                    break;
+                    return total;
                 }
             }
         }


### PR DESCRIPTION
PassThroughMessageProcessor threads go to waiting state and Gateway Node becomes slow/unresponsive. This fix is to resolve that.
Associated JIRA is https://wso2.org/jira/browse/APIMANAGER-5607