### PR TITLE
Fixed for APIM become slow/unresponsive and all synapse threads wait on PassThroughMessageProcessor-[IdentityEncoder]

### DIFF
--- a/modules/httpcore-nio/src/main/java/org/apache/http/impl/nio/codecs/IdentityEncoder.java
+++ b/modules/httpcore-nio/src/main/java/org/apache/http/impl/nio/codecs/IdentityEncoder.java
@@ -88,7 +88,7 @@ public class IdentityEncoder extends AbstractContentEncoder
         assertNotCompleted();
 
         int total = 0;
-        while (src.hasRemaining()) {
+        if (src.hasRemaining()) {
             if (this.buffer.hasData() || this.fragHint > 0) {
                 if (src.remaining() <= this.fragHint) {
                     final int capacity = this.fragHint - this.buffer.length();
@@ -103,7 +103,7 @@ public class IdentityEncoder extends AbstractContentEncoder
                 if (this.buffer.length() >= this.fragHint || src.hasRemaining()) {
                     final int bytesWritten = flushToChannel();
                     if (bytesWritten == 0) {
-                        break;
+                        return total;
                     }
                 }
             }
@@ -111,7 +111,7 @@ public class IdentityEncoder extends AbstractContentEncoder
                 final int bytesWritten = writeToChannel(src);
                 total += bytesWritten;
                 if (bytesWritten == 0) {
-                    break;
+                    return total;
                 }
             }
         }


### PR DESCRIPTION
Updated IdentityEncoder.java to fix the below bug:
 https://wso2.org/jira/browse/APIMANAGER-6108