### PR TITLE
Fix server trying to close the SSLsession in a loop

### DIFF
--- a/modules/httpcore-nio/src/main/java/org/apache/http/nio/reactor/ssl/SSLIOSession.java
+++ b/modules/httpcore-nio/src/main/java/org/apache/http/nio/reactor/ssl/SSLIOSession.java
@@ -336,10 +336,10 @@ public class SSLIOSession implements IOSession, SessionBufferStatus, SocketAcces
             newMask = EventMask.READ;
             break;
         case NOT_HANDSHAKING:
-            if (!(status == CLOSING && !isInboundDone() && isOutboundDone())) {
-                newMask = this.appEventMask;
-            } else {
+            if (this.status >= CLOSING && isOutboundDone()) {
                 newMask = EventMask.READ;
+            } else {
+                newMask = this.appEventMask;
             }
             break;
         case NEED_TASK:

--- a/modules/httpcore-nio/src/main/java/org/apache/http/nio/reactor/ssl/SSLIOSession.java
+++ b/modules/httpcore-nio/src/main/java/org/apache/http/nio/reactor/ssl/SSLIOSession.java
@@ -336,7 +336,11 @@ public class SSLIOSession implements IOSession, SessionBufferStatus, SocketAcces
             newMask = EventMask.READ;
             break;
         case NOT_HANDSHAKING:
-            newMask = this.appEventMask;
+            if (!(status == CLOSING && !isInboundDone() && isOutboundDone())) {
+                newMask = this.appEventMask;
+            } else {
+                newMask = EventMask.READ;
+            }
             break;
         case NEED_TASK:
             break;


### PR DESCRIPTION
## Purpose

After the HTTPS response is written back to the client, the server tries to close the connection and the SSLIOSession. Prior to JDK 8 261 versions (& Prior to Oracle JDK 11.0.2), after SSLIOSession closes the outBound connection, the Handshake status is returned as NEED_UNWRAP. When such status is returned, we set the new event Mask as Read EventMask. In the new JDK versions it is returned as NOT_HANDSHAKING. In such cases, the SSLSession is not getting closed properly, and the server is constantly trying to close the connection which causes the CPU spike. We debugged the JDK code, and we were able to find a [commit](https://github.com/AdoptOpenJDK/openjdk-jdk11u/commit/8d1b63a4db2c6348a97b3cf45bd4d2caa7cad6b5), which might have caused this behaviour. With this JDK commit, TransportContext Handshake status is returned as NOT_HANDSHAKING even after closeOutbound() is called. (The issue is reproducible for both TLSv1.2 and TLSv1.3)

This issue can be reproduced for any HTTPS request if Connection Keep Alive is disabled (or Connection: close header is present).