### PR TITLE
Fixes the one second delay between ssl chunk reads

### DIFF
--- a/modules/httpcore-nio/src/main/java/org/apache/http/nio/reactor/ssl/SSLIOSession.java
+++ b/modules/httpcore-nio/src/main/java/org/apache/http/nio/reactor/ssl/SSLIOSession.java
@@ -53,6 +53,7 @@ import org.apache.http.util.Args;
 import org.apache.http.util.Asserts;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.channels.Selector;
 
 /**
  * <tt>SSLIOSession</tt> is a decorator class intended to transparently extend
@@ -81,6 +82,7 @@ public class SSLIOSession implements IOSession, SessionBufferStatus, SocketAcces
     public static final String SESSION_KEY = "http.session.ssl";
 
     private final IOSession session;
+    private final Selector selector;
     private final SSLEngine sslEngine;
     private final ByteBuffer inEncrypted;
     private final ByteBuffer outEncrypted;
@@ -158,6 +160,7 @@ public class SSLIOSession implements IOSession, SessionBufferStatus, SocketAcces
         final int appBuffersize = this.sslEngine.getSession().getApplicationBufferSize();
         this.inPlain = ByteBuffer.allocate(appBuffersize);
         this.outPlain = ByteBuffer.allocate(appBuffersize);
+        this.selector = ((IOSessionImpl) this.session).getKey().selector();
     }
 
     protected SSLSetupHandler getSSLSetupHandler() {
@@ -311,7 +314,12 @@ public class SSLIOSession implements IOSession, SessionBufferStatus, SocketAcces
         }
     }
 
-    private void updateEventMask() {
+    /**
+     * Updates the Mask for the session.
+     *
+     * @return whether selector is waked up upon updating the mask
+     */
+    private boolean updateEventMask() {
         // Graceful session termination
         if (this.status == CLOSING && this.sslEngine.isOutboundDone()
                 && (this.endOfStream || this.sslEngine.isInboundDone())) {
@@ -324,7 +332,7 @@ public class SSLIOSession implements IOSession, SessionBufferStatus, SocketAcces
         }
         if (this.status == CLOSED) {
             this.session.close();
-            return;
+            return true;
         }
         // Need to toggle the event mask for this channel?
         final int oldMask = this.session.getEventMask();
@@ -354,12 +362,12 @@ public class SSLIOSession implements IOSession, SessionBufferStatus, SocketAcces
             newMask = newMask | EventMask.WRITE;
         }
 
+        boolean updateMask = oldMask != newMask;
         // Update the mask if necessary
-        if (oldMask != newMask) {
+        if (updateMask) {
             this.session.setEventMask(newMask);
-        } else {
-            ((IOSessionImpl) this.session).getKey().selector().wakeup();
         }
+        return updateMask;
     }
 
     private int sendEncryptedData() throws IOException {
@@ -517,7 +525,9 @@ public class SSLIOSession implements IOSession, SessionBufferStatus, SocketAcces
         }
         this.status = CLOSING;
         this.sslEngine.closeOutbound();
-        updateEventMask();
+        if (!updateEventMask() && this.selector.isOpen()) {
+            this.selector.wakeup();
+        }
     }
 
     public synchronized void shutdown() {
@@ -554,17 +564,23 @@ public class SSLIOSession implements IOSession, SessionBufferStatus, SocketAcces
 
     public synchronized void setEventMask(final int ops) {
         this.appEventMask = ops;
-        updateEventMask();
+        updateEventMaskAndWakeUpSelector();
     }
 
     public synchronized void setEvent(final int op) {
         this.appEventMask = this.appEventMask | op;
-        updateEventMask();
+        updateEventMaskAndWakeUpSelector();
     }
 
     public synchronized void clearEvent(final int op) {
         this.appEventMask = this.appEventMask & ~op;
-        updateEventMask();
+        updateEventMaskAndWakeUpSelector();
+    }
+
+    private void updateEventMaskAndWakeUpSelector() {
+        if (!updateEventMask()) {
+            this.selector.wakeup();
+        }
     }
 
     public int getSocketTimeout() {


### PR DESCRIPTION
Fixes https://wso2.org/jira/browse/ESBJAVA-4568.

When the ESB requests to update or clear a event, the selector needs to be waked up all the time
else it will wait in it for select timeout which will cause delays between ssl chunks.

The original fix b863ad5 is done to wake up selector each time when the event mask is updated lead to high cpu usage since its not necessary at times and only needed if we request / in or out

Issue:- https://github.com/wso2/product-ei/issues/5259