### PR TITLE
Close SSL IO session if SSLEngine result is failed

### DIFF
--- a/modules/httpcore-nio/src/main/java/org/apache/http/nio/reactor/ssl/SSLIOSession.java
+++ b/modules/httpcore-nio/src/main/java/org/apache/http/nio/reactor/ssl/SSLIOSession.java
@@ -493,6 +493,9 @@ public class SSLIOSession implements IOSession, SessionBufferStatus, SocketAcces
             final SSLEngineResult result = doWrap(src, this.outEncrypted);
             if (result.getStatus() == Status.CLOSED) {
                 this.status = CLOSED;
+                // changing only the status will prevent the shutdown function being triggered.
+                // hence we need to close the session here itself to prevent error loops.
+                this.session.close();
             }
             return result.bytesConsumed();
         } else {


### PR DESCRIPTION
## Purpose
> Changing only the status will prevent the shutdown function being triggered. Hence we need to close the session here itself to prevent error loops.

## Goals
> Closing the session. 

## Related PRs
> https://github.com/wso2-support/wso2-httpcore-nio/pull/13