### PR TITLE
Non-blocking SSL I/O session incorrectly sets read interest when the session is being closed even if the application layer has cleared interest in input causing to a busy loop in the I/O event loop and am excessive CPU utilization

### DIFF
--- a/modules/httpcore-nio/src/main/java/org/apache/http/nio/reactor/ssl/SSLIOSession.java
+++ b/modules/httpcore-nio/src/main/java/org/apache/http/nio/reactor/ssl/SSLIOSession.java
@@ -427,8 +427,6 @@ public class SSLIOSession implements IOSession, SessionBufferStatus, SocketAcces
                 !this.inPlain.hasData() &&
                 (this.appBufferStatus == null || !this.appBufferStatus.hasBufferedInput())) {
             newMask = newMask & ~EventMask.READ;
-        } else if (this.status == CLOSING) {
-            newMask = newMask | EventMask.READ;
         }
 
         // Do we have encrypted data ready to be sent?


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/api-manager/issues/977

