### PR TITLE
Handle partial data remaining within inEncrypted buffer

### DIFF
--- a/modules/httpcore-nio/src/main/java/org/apache/http/nio/reactor/ssl/SSLIOSession.java
+++ b/modules/httpcore-nio/src/main/java/org/apache/http/nio/reactor/ssl/SSLIOSession.java
@@ -643,7 +643,7 @@ public class SSLIOSession implements IOSession, SessionBufferStatus, SocketAcces
             }
             return n;
         }
-        return this.endOfStream ? -1 : 0;
+        return this.endOfStream && !this.inEncrypted.hasData() ? -1 : 0;
     }
 
     @Override

--- a/modules/httpcore-nio/src/main/java/org/apache/http/nio/reactor/ssl/SSLIOSession.java
+++ b/modules/httpcore-nio/src/main/java/org/apache/http/nio/reactor/ssl/SSLIOSession.java
@@ -425,7 +425,7 @@ public class SSLIOSession implements IOSession, SessionBufferStatus, SocketAcces
         }
 
         if (this.endOfStream &&
-                !this.inPlain.hasData() &&
+                !this.inPlain.hasData() && !this.inEncrypted.hasData() &&
                 (this.appBufferStatus == null || !this.appBufferStatus.hasBufferedInput())) {
             newMask = newMask & ~EventMask.READ;
         }

--- a/modules/httpcore-nio/src/main/java/org/apache/http/nio/reactor/ssl/SSLIOSession.java
+++ b/modules/httpcore-nio/src/main/java/org/apache/http/nio/reactor/ssl/SSLIOSession.java
@@ -383,7 +383,8 @@ public class SSLIOSession implements IOSession, SessionBufferStatus, SocketAcces
     private void updateEventMask() {
         // Graceful session termination
         if (this.status == ACTIVE
-                && (this.endOfStream || this.sslEngine.isInboundDone())) {
+                && (this.endOfStream || this.sslEngine.isInboundDone())
+                && !this.inPlain.hasData() && !this.inEncrypted.hasData()) {
             this.status = CLOSING;
         }
         if (this.status == CLOSING && !this.outEncrypted.hasData()) {


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

This PR contains the following fixes.

- [Prevent premature session closure when backend close connection](https://github.com/wso2/wso2-httpcore-nio/commit/bb86d5908179ee523e7f8a0d1cd77ff2cabc1f96)
When a backend sends a response and immediately closes the connection, there might be scenarios where there can be data not consumed in the inPlain buffer because the IOSession has been closed. As a result, the decoder does not get completed and the client does not receive the response. This fix prevents the session from going into CLOSING state prematurely. Resolves https://github.com/wso2/api-manager/issues/1989

- [Fix ChunkDecoder premature completion when back-end closes connection](https://github.com/wso2/wso2-httpcore-nio/commit/ada889611fc320a7fcf5a278c0e68727b6006230)
ChunkDecoder completes when the endOfStream property is set to true. When there is SSLIOSession involved, this property sets to true soon after the input channel reaches its end of stream. But the SSLIOSession's inEncrypted buffer can be half consumed at this state. So this fix avoids setting endOfStream true until the inEncrypted buffer is Fully consumed. Resolves 
https://github.com/wso2/wso2-httpcore-nio/issues/49

- [Avoid removing read interest while data remains in inEncrypted buffer](https://github.com/wso2/wso2-httpcore-nio/commit/963e02d69a63bf7f3b7592239ca756c163444b76)
Sometimes the read interest is removed in SSLIOSession, when there are remaining data available in the inEncrypted buffer which leads to incomplete payload. This PR fixes this issue by adding a condition to check for remaining data in the inEncrypted buffer. Resolves https://github.com/wso2/api-manager/issues/2134