### PR TITLE
Make 'endpoints' a ConcurrentHashMap to fix ConcurrentModificationException occurs while pausing the DefaultListeningIOReactor

### DIFF
--- a/modules/httpcore-nio/src/main/java/org/apache/http/impl/nio/reactor/DefaultListeningIOReactor.java
+++ b/modules/httpcore-nio/src/main/java/org/apache/http/impl/nio/reactor/DefaultListeningIOReactor.java
@@ -34,11 +34,11 @@ import java.nio.channels.CancelledKeyException;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Queue;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ThreadFactory;
 
@@ -81,7 +81,7 @@ public class DefaultListeningIOReactor extends AbstractMultiworkerIOReactor
             final ThreadFactory threadFactory) throws IOReactorException {
         super(config, threadFactory);
         this.requestQueue = new ConcurrentLinkedQueue<ListenerEndpointImpl>();
-        this.endpoints = Collections.synchronizedSet(new HashSet<ListenerEndpointImpl>());
+        this.endpoints = ConcurrentHashMap.newKeySet();
         this.pausedEndpoints = new HashSet<SocketAddress>();
     }
 


### PR DESCRIPTION
## Purpose
When multiple threads are adding/removing endpoints frequently, `Collections.synchronizedSet` becomes cumbersome. Also, if every access is not synchronized on the same lock, there can be ConcurrentModificationException happening. 

Hence, replacing the `endpoints` set with a concurrent collection:

`private final Set<ListenerEndpointImpl> endpoints = ConcurrentHashMap.newKeySet();`

This eliminates CME because ConcurrentHashMap.newKeySet() allows safe concurrent iteration + modification.
