### PR TITLE
Prevent CPU spin by clearing leftover SSL buffer after shutdown

### DIFF
--- a/modules/httpcore-nio/src/main/java/org/apache/http/nio/reactor/ssl/SSLIOSession.java
+++ b/modules/httpcore-nio/src/main/java/org/apache/http/nio/reactor/ssl/SSLIOSession.java
@@ -526,6 +526,14 @@ public class SSLIOSession implements IOSession, SessionBufferStatus, SocketAcces
                 } else {
                     if (status == Status.BUFFER_UNDERFLOW && this.endOfStream) {
                         throw new SSLException("Unable to decrypt incoming data due to unexpected end of stream");
+                    } else if (status == Status.CLOSED && this.sslEngine.isInboundDone()) {
+                        if (this.inEncrypted.hasData()) {
+                            // Handle graceful TLS inbound closure by detecting when the SSLEngine has received or
+                            // sent the final close_notify and all encrypted data has been processed.
+                            // This marks the clean end-of-stream for TLS, where unwrap() will no longer produce data,
+                            // remaining encrypted bytes can be safely discarded, and the connection should be closed.
+                            inEncryptedBuf.clear();
+                        }
                     }
                     break;
                 }


### PR DESCRIPTION


## Purpose
Handle Status.CLOSED with inbound done state in SSLIOSession. Clear any remaining encrypted bytes to avoid OP_READ loop spins after TLS shutdown.

Fixes: https://github.com/wso2/product-micro-integrator/issues/4392