### PR TITLE
Add warn logs for hard shutdown trigger paths

### DIFF
--- a/modules/httpcore-nio/pom.xml
+++ b/modules/httpcore-nio/pom.xml
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
-            <scope>test</scope>
+            <scope>compile</scope>
         </dependency>
     </dependencies>
 

--- a/modules/httpcore-nio/src/main/java/org/apache/http/impl/nio/reactor/AbstractIOReactor.java
+++ b/modules/httpcore-nio/src/main/java/org/apache/http/impl/nio/reactor/AbstractIOReactor.java
@@ -41,6 +41,8 @@ import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.http.nio.reactor.IOReactor;
 import org.apache.http.nio.reactor.IOReactorException;
 import org.apache.http.nio.reactor.IOReactorStatus;
@@ -56,6 +58,8 @@ import org.apache.http.util.Asserts;
  * @since 4.0
  */
 public abstract class AbstractIOReactor implements IOReactor {
+
+    private final Log log = LogFactory.getLog(AbstractIOReactor.class);
 
     private volatile IOReactorStatus status;
 
@@ -254,13 +258,18 @@ public abstract class AbstractIOReactor implements IOReactor {
                 try {
                     readyCount = this.selector.select(this.selectTimeout);
                 } catch (final InterruptedIOException ex) {
+                    log.warn("I/O reactor hard shutdown trigger : selector.select() was interrupted. ", ex);
                     throw ex;
                 } catch (final IOException ex) {
+                    log.warn("I/O reactor hard shutdown trigger : selector.select() failed. ", ex);
                     throw new IOReactorException("Unexpected selector failure", ex);
                 }
 
                 if (this.status == IOReactorStatus.SHUT_DOWN) {
                     // Hard shut down. Exit select loop immediately
+                    log.warn("I/O reactor execute loop detected SHUT_DOWN state. "
+                                    + "Exiting select loop immediately.",
+                            new Exception("I/O reactor hard shutdown path reached"));
                     break;
                 }
 
@@ -300,7 +309,11 @@ public abstract class AbstractIOReactor implements IOReactor {
 
             }
 
-        } catch (final ClosedSelectorException ignore) {
+        } catch (final ClosedSelectorException ex) {
+            log.warn("I/O reactor hard shutdown trigger: ClosedSelectorException in execute loop.", ex);
+        } catch (IOReactorException exception) {
+            log.warn("I/O reactor hard shutdown trigger: IOReactorException in execute loop.", exception);
+            throw exception;
         } finally {
             hardShutdown();
             synchronized (this.statusMutex) {
@@ -588,7 +601,6 @@ public abstract class AbstractIOReactor implements IOReactor {
             }
             this.status = IOReactorStatus.SHUT_DOWN;
         }
-
         closeNewChannels();
         closeActiveChannels();
         processClosedSessions();
@@ -627,6 +639,9 @@ public abstract class AbstractIOReactor implements IOReactor {
             }
         }
         if (this.status != IOReactorStatus.SHUT_DOWN) {
+            log.warn("I/O reactor hard shutdown trigger: Graceful shutdown " +
+                            "did not complete within the given grace period. Initiating hard shutdown.",
+                    new Exception("I/O reactor hard shutdown path reached"));
             hardShutdown();
         }
     }

--- a/modules/httpcore-nio/src/main/java/org/apache/http/impl/nio/reactor/AbstractMultiworkerIOReactor.java
+++ b/modules/httpcore-nio/src/main/java/org/apache/http/impl/nio/reactor/AbstractMultiworkerIOReactor.java
@@ -42,6 +42,8 @@ import java.util.List;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicLong;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.http.nio.params.NIOReactorPNames;
 import org.apache.http.nio.reactor.IOEventDispatch;
 import org.apache.http.nio.reactor.IOReactor;
@@ -96,6 +98,8 @@ import org.apache.http.util.Asserts;
  */
 @SuppressWarnings("deprecation")
 public abstract class AbstractMultiworkerIOReactor implements IOReactor {
+
+    private final Log log = LogFactory.getLog(AbstractMultiworkerIOReactor.class);
 
     protected volatile IOReactorStatus status;
 
@@ -332,6 +336,9 @@ public abstract class AbstractMultiworkerIOReactor implements IOReactor {
 
             for (int i = 0; i < this.workerCount; i++) {
                 if (this.status != IOReactorStatus.ACTIVE) {
+                    log.warn("I/O reactor shutdown path: execute() is exiting before starting all worker threads "
+                                    + "because status changed to " + this.status + ".",
+                            new Exception("execute() exiting before worker startup completion"));
                     return;
                 }
                 this.threads[i].start();
@@ -342,8 +349,10 @@ public abstract class AbstractMultiworkerIOReactor implements IOReactor {
                 try {
                     readyCount = this.selector.select(this.selectTimeout);
                 } catch (final InterruptedIOException ex) {
+                    log.warn("I/O reactor hard shutdown trigger: selector.select() was interrupted.", ex);
                     throw ex;
                 } catch (final IOException ex) {
+                    log.warn("I/O reactor hard shutdown trigger: selector.select() failed.", ex);
                     throw new IOReactorException("Unexpected selector failure", ex);
                 }
 
@@ -362,13 +371,18 @@ public abstract class AbstractMultiworkerIOReactor implements IOReactor {
                 }
 
                 if (this.status.compareTo(IOReactorStatus.ACTIVE) > 0) {
+                    log.debug("I/O reactor shutdown path: execute() detected reactor status "
+                                    + this.status + " and is exiting the select loop.",
+                            new Exception("execute() exiting because reactor is no longer ACTIVE"));
                     break;
                 }
             }
 
         } catch (final ClosedSelectorException ex) {
+            log.warn("I/O reactor hard shutdown trigger: ClosedSelectorException in execute().", ex);
             addExceptionEvent(ex);
         } catch (final IOReactorException ex) {
+            log.warn("I/O reactor hard shutdown trigger: IOReactorException in execute().", ex);
             if (ex.getCause() != null) {
                 addExceptionEvent(ex.getCause());
             }


### PR DESCRIPTION

## Purpose
Add warning logs in reactor execute paths that can lead to hard shutdown. This improves visibility
into the abnormal execution flow that causes the
reactor to exit and enter shutdown handling.

The added logs focus on trigger paths in execute
methods instead of normal shutdown paths, so the
output remains useful for diagnosing unexpected
reactor termination.

Fixes: https://github.com/wso2/product-micro-integrator/issues/4719
